### PR TITLE
파이썬 3.8 이상에서 MutableMapping 경로 변경

### DIFF
--- a/gistory/bottle.py
+++ b/gistory/bottle.py
@@ -98,7 +98,10 @@ if py3k:
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
     urlunquote = functools.partial(urlunquote, encoding='latin1')
     from http.cookies import SimpleCookie
-    from collections import MutableMapping as DictMixin
+    if sys.version_info[:2] >= (3, 8):
+        from collections.abc import MutableMapping as DictMixin
+    else:
+        from collections import MutableMapping as DictMixin
     import pickle
     from io import BytesIO
     from configparser import ConfigParser


### PR DESCRIPTION
파이썬 3.8부터 MutableMapping의 경로가 collections에서 collections.abc로 바뀌었습니다. 버전 체크 구문을 넣었습니다.